### PR TITLE
fix: Align text size with recommended character limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.2.0
+
+- Align character-limit with GC Design System recommendations by default.
+
+  To remove the character limit, set `disableCharacterlimit` to `true`
+  on a page's params or globally with the site's params.
+
 ## v0.1.1
 
 ### Fixed

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -85,3 +85,13 @@ gcds-container ul {
     margin-top: 0.5em;
   }
 }
+
+.character-limit gcds-container {
+  li, dt, dd {
+    max-width: var(--gcds-text-character-limit);
+  }
+}
+
+pre {
+  padding: 1em;
+}

--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,4 +1,4 @@
 <!-- For more information, visit: https://design-system.alpha.canada.ca/en/components/heading/ -->
-<gcds-heading tag="h{{ .Level }}" id="{{ .Anchor }}" character-limit="false">
+<gcds-heading tag="h{{ .Level }}" id="{{ .Anchor }}" character-limit="{{ not (.Page.Params.disableCharacterLimit | default .Page.Site.Params.disableCharacterLimit) }}">
   {{- .Text -}}
 </gcds-heading>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -13,7 +13,7 @@
     <link rel="icon" href="{{ "/favicon.ico" | relURL }}" type="image/x-icon" />
 
     {{ partial "analytics" . }}
-    
+
     <!-- Icons Font Awesome -->
     {{ partial "assets/font-awesome.html" }}
 
@@ -42,7 +42,7 @@
 
     {{ partial "hooks/head-end.html" . -}}
   </head>
-  <body style="margin: 0">
+  <body style="margin: 0" {{ if (not (.Page.Params.disableCharacterLimit | default .Page.Site.Params.disableCharacterLimit)) }}class="character-limit"{{ end }}>
     <main>
       {{ block "main" . }}{{ end }}
     </main>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -33,7 +33,7 @@
             {{ .TableOfContents }}
           </gcds-fieldset>
         {{ end }}
-        {{ $content := .Content | replaceRE "<p>(.*?)</p>" "<gcds-text character-limit=\"false\">$1</gcds-text>" }}
+        {{ $content := .Content | replaceRE `(?s:<p>(.*?)</p>)` (printf "<gcds-text character-limit=\"%v\">$1</gcds-text>" (not (.Page.Params.disableCharacterLimit | default .Site.Params.disableCharacterLimit))) }}
         {{ $content | safeHTML }}
 
         {{- if not $showSidebar -}}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -24,7 +24,7 @@
       {{ end }}
       <section class="mb-400">
         {{ partial "heading" . }}
-        {{ $intro := .Params.Intro | markdownify | replaceRE "<p>(.*?)</p>" "<gcds-text character-limit=\"false\">$1</gcds-text>" }}
+        {{ $intro := .Params.Intro | markdownify | replaceRE `(?s:<p>(.*?)</p>)` (printf "<gcds-text character-limit=\"%v\">$1</gcds-text>" (not (.Page.Params.disableCharacterLimit | default .Site.Params.disableCharacterLimit))) }}
         {{ $intro | safeHTML }}
         {{ $showToc := or .Params.showToc .Site.Params.showToc }}
         {{ if and $showToc .TableOfContents }}
@@ -35,7 +35,7 @@
             {{ .TableOfContents }}
           </gcds-fieldset>
         {{ end }}
-        {{ $content := .Content | replaceRE "<p>(.*?)</p>" "<gcds-text character-limit=\"false\">$1</gcds-text>" }}
+        {{ $content := .Content | replaceRE `(?s:<p>(.*?)</p>)`  (printf "<gcds-text character-limit=\"%v\">$1</gcds-text>" (not (.Page.Params.disableCharacterLimit | default .Site.Params.disableCharacterLimit))) }}
         {{ $content | safeHTML }}
         {{ partial "date-modified" . }}
       </section>

--- a/layouts/components/list.html
+++ b/layouts/components/list.html
@@ -24,7 +24,7 @@
       {{ end }}
       <section class="mb-400">
         {{ partial "heading" . }}
-        {{ $content := .Content | replaceRE "<p>(.*?)</p>" "<gcds-text character-limit=\"false\">$1</gcds-text>" }}
+        {{ $content := .Content | replaceRE `(?s:<p>(.*?)</p>)` (printf "<gcds-text character-limit=\"%v\">$1</gcds-text>" (not (.Page.Params.disableCharacterLimit | default .Site.Params.disableCharacterLimit))) }}
         {{ $content | safeHTML }}
         <gcds-heading tag="h2">{{ i18n "components_browse" | default "Browse Components" }}</gcds-heading>
         <div class="my-500">


### PR DESCRIPTION
This PR also fixes issues with the `<p>` replacement where it doesn't match when there are new lines in the content.