### PR TITLE
fix(html/base): ensure that the language and language direction attributes are set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## v.2.2
+## v0.2.3
+
+- Added dynamic language and language direction rendering to themes base layout
+
+## v0.2.2
 
 - All Pilcrow functionality to headers
 - Add markdownlint-cli2

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,7 @@
 <!doctype html>
-<html dir="ltr" lang="en">
+<html itemscope itemtype="http://schema.org/WebPage"
+    {{- with .Site.Language.LanguageDirection }} dir="{{ . }}" {{- end -}}
+    {{ with .Site.Language.Lang }} lang="{{ . }}" {{- end }}>
   <head>
     <meta charset="utf-8" />
     <meta


### PR DESCRIPTION
Currently the `lang` and `ltr` attributes on the `html` tag for the base layout are not set dynamically and are statically configured to be `en` and `ltr` respectively. 

This PR introduces a change that will dynamically update these attributes based on the current site language.

This is useful for other dynamic functionality that depends on these attributes in order to determine the language.